### PR TITLE
lay groundwork for ttl

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -53,7 +53,7 @@ class Anonymoose < Sinatra::Base
       context.add_log_data(:file_extension, File.extname(file[:filename]))
 
       if hashed_link
-        erb :upload_success, locals: { link: hashed_link, ttl: ttl / 60 }
+        erb :upload_success, locals: { link: hashed_link }
       else
         puts "File upload failed"
         @error_message = "File upload failed. Please upload a valid file."

--- a/app/handlers/file_handler.rb
+++ b/app/handlers/file_handler.rb
@@ -3,10 +3,18 @@ require 'securerandom'
 require_relative 's3_handler'
 
 class FileHandler
+  TTL = {
+    1 => 900, # 15 minutes
+    2 => 3600, # 1 hour
+    3 => 14400, # 4 hours
+    4 => 28800, # 8 hours
+    5 => 86400, # 1 day
+  }.freeze
+
   def initialize(file, cache, ttl = 0)
     @file = file
     @cache = cache
-    @ttl = ttl
+    @ttl = TTL[ttl] || TTL[1]
     @s3_handler = S3Handler.new
   end
 
@@ -17,11 +25,8 @@ class FileHandler
     unique_id = SecureRandom.uuid
     hash_name = generate_hashed_link(unique_id)
 
-    puts "Generated unique_id: #{unique_id}"  # Debugging
-    puts "Generated hash_name: #{hash_name}"  # Debugging
-
     begin
-      @s3_handler.upload_file(tempfile, unique_id)
+      @s3_handler.upload_file(tempfile, unique_id, @ttl)
       cache_metadata(hash_name, unique_id, filename)
       hash_name
     rescue => e

--- a/app/handlers/file_handler.rb
+++ b/app/handlers/file_handler.rb
@@ -4,6 +4,9 @@ require_relative 's3_handler'
 
 class FileHandler
   TTL = {
+    t0: 0, # No expiration
+    t1: 2, # 2 seconds
+    t2: 15, # 15 seconds
     1 => 900, # 15 minutes
     2 => 3600, # 1 hour
     3 => 14400, # 4 hours

--- a/app/handlers/s3_handler.rb
+++ b/app/handlers/s3_handler.rb
@@ -15,7 +15,6 @@ class S3Handler
 
   def upload_file(tempfile, unique_id, ttl)
     expiration_date = Time.now.utc + ttl
-    puts "Uploading file to MinIO with key: #{unique_id}"  # Debugging
     @client.put_object(
       bucket: @bucket,
       key: unique_id,
@@ -27,7 +26,6 @@ class S3Handler
       object_lock_retain_until_date: expiration_date.iso8601
     )
 
-    puts "File uploaded successfully."  # Debugging
   rescue => e
     puts "Error uploading file to S3: #{e.message}"
     raise

--- a/test/integration/anonoymoose_test.rb
+++ b/test/integration/anonoymoose_test.rb
@@ -43,7 +43,7 @@ class AnonymooseTest < Minitest::Test
 
   def test_file_upload
     file = Rack::Test::UploadedFile.new('test/test.txt', 'text/plain')
-    post '/upload', { file: file, expiration: '15' }
+    post '/upload', { file: file, expiration: 1 }
 
     assert last_response.ok?
     assert_includes last_response.body, 'Upload Success'

--- a/test/unit/file_handler_test.rb
+++ b/test/unit/file_handler_test.rb
@@ -32,23 +32,19 @@ class FileHandlerTest < Minitest::Test
   end
 
   def test_file_save_and_cache
-    ttl = 15  # 15 seconds TTL
+    ttl = :t2  # 15 seconds TTL
     file_handler = FileHandler.new(@file, @cache, ttl)
     hash_name = file_handler.save
-    puts "Upload response: #{hash_name.inspect}"
 
     assert hash_name, "Hash name should be generated"
-    puts "Generated hash name: #{hash_name}"  # Debugging
 
     metadata = @cache.get(hash_name)
     unique_id = metadata[:unique_id] if metadata
-    puts "Cached metadata: #{metadata.inspect}"  # Debugging
 
     sleep 5 # Temp fix for CI
 
     # Check if file is saved in MinIO
     object_exists = s3_object_exists?(unique_id)
-    puts "Object exists in MinIO: #{object_exists}"  # Debugging
     assert object_exists, "File should be saved in MinIO"
 
     # Check if metadata is cached
@@ -57,11 +53,11 @@ class FileHandlerTest < Minitest::Test
   end
 
   def test_ttl_expiration
-    ttl = 2  # 2 seconds TTL
+    ttl = :t1  # 2 seconds TTL
     file_handler = FileHandler.new(@file, @cache, ttl)
     hash_name = file_handler.save
 
-    sleep(ttl + 3)  # Wait for TTL to expire
+    sleep(5)  # Wait for TTL to expire
 
     metadata = @cache.get(hash_name)
     assert_nil metadata, "Metadata should expire and be nil"

--- a/views/upload.erb
+++ b/views/upload.erb
@@ -16,11 +16,11 @@
     <div class="field">
       <label for="expiration">Choose expiration:</label>
       <select name="expiration" id="expiration" class="round">
-        <option value="900">15 Minutes</option>
-        <option value="3600">1 Hour</option>
-        <option value="14400">4 Hours</option>
-        <option value="28800">8 Hours</option>
-        <option value="86400">1 Day</option>
+        <option value="1">15 Minutes</option>
+        <option value="2">1 Hour</option>
+        <option value="3">4 Hours</option>
+        <option value="4">8 Hours</option>
+        <option value="5">1 Day</option>
       </select>
     </div>
     <button type="submit" class="round">Upload</button>

--- a/views/upload_success.erb
+++ b/views/upload_success.erb
@@ -7,7 +7,7 @@
   <div class="max">
     <h6 class="small">Right click to copy to copy your link</h6>
   </div>
-  <label>Link Expires in : <%= ttl %> minutes</label>
+  <label>Remember, your link will expire!</label>
   </a>
   <a href="/" class="border round button">Home</a>
 </article>


### PR DESCRIPTION
TTL settings are changed in the form and in memcached. Foundation has been laid in minio but it doesn't have TTL out of the box.

Added metadata that we will sweep by adding a sidekiq job to delete files older than the TTL metadata.