### PR TITLE
get originating ip for logging

### DIFF
--- a/app/handlers/s3_handler.rb
+++ b/app/handlers/s3_handler.rb
@@ -21,11 +21,8 @@ class S3Handler
       body: tempfile,
       metadata: {
         'x-amz-meta-expiration' => expiration_date.iso8601
-      },
-      object_lock_mode: 'GOVERNANCE',
-      object_lock_retain_until_date: expiration_date.iso8601
+      }
     )
-
   rescue => e
     puts "Error uploading file to S3: #{e.message}"
     raise
@@ -42,11 +39,10 @@ class S3Handler
 
   def create_bucket_unless_exists
     unless bucket_exists?
-      @client.create_bucket(
-        bucket: @bucket,
-        object_lock_enabled_for_bucket: true
-      )
-      puts "Bucket #{@bucket} with object lock created."
+      @client.create_bucket(bucket: @bucket)
+      puts "Bucket #{@bucket} created."
+    else
+      puts "Bucket #{@bucket} already exists."
     end
   rescue Aws::S3::Errors::BucketAlreadyExists, Aws::S3::Errors::BucketAlreadyOwnedByYou
     puts "Bucket #{@bucket} already exists."

--- a/app/middleware/headers_middleware.rb
+++ b/app/middleware/headers_middleware.rb
@@ -25,8 +25,12 @@ class HeadersMiddleware
   private
 
   def extract_ip(env)
-    if env['HTTP_X_FORWARDED_FOR']
+    if env['HTTP_CF_CONNECTING_IP']
+      env['HTTP_CF_CONNECTING_IP']
+    elsif env['HTTP_X_FORWARDED_FOR']
       env['HTTP_X_FORWARDED_FOR'].split(',').first.strip
+    elsif env['HTTP_X_REAL_IP']
+      env['HTTP_X_REAL_IP']
     else
       env['REMOTE_ADDR']
     end

--- a/test/unit/file_handler_test.rb
+++ b/test/unit/file_handler_test.rb
@@ -35,7 +35,7 @@ class FileHandlerTest < Minitest::Test
     ttl = :t2  # 15 seconds TTL
     file_handler = FileHandler.new(@file, @cache, ttl)
     hash_name = file_handler.save
-
+    puts hash_name
     assert hash_name, "Hash name should be generated"
 
     metadata = @cache.get(hash_name)


### PR DESCRIPTION
Adding 3 different headers to attempt to grab originating ip:

1. HTTP_CF_CONNECTING_IP
2. HTTP_X_FORWARDED_FOR
3. HTTP_X_REAL_IP

Note: I decided to remove the object lock from the instantiation of the bucket. Locking causes issues and retention policy is set to days when we want to remove files within the same day.

Instead we will pivot to using sidekiq running a job to search the s3 bucket for metadata on ttl's that have passed their time.