### PR TITLE
File throttle

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -31,34 +31,21 @@ class Anonymoose < Sinatra::Base
 
   post '/upload' do
     puts "Received params: #{params.inspect}"
-
+    
     ttl = params[:expiration].to_i
     file = params[:file]
     context = env['request_context']
-  
+    
     if file.nil?
-      @error_message = 'No file received'
-      return erb :upload
+      halt 400, 'No file received'
     end
   
     file_size = file[:tempfile].size
     if file_size > MAX_UPLOAD_SIZE
-      @error_message = "File size exceeds the maximum limit of #{MAX_UPLOAD_SIZE / 1024 / 1024} MB"
-      return erb :upload
+      halt 413, 'File size exceeds the maximum limit'
     end
   
     if file
-      # Throttle upload speed to 50 KB/s
-      throttle_speed_kbps = 50
-      chunk_size = 1024 # 1 KB
-      tempfile = file[:tempfile]
-      
-      File.open(tempfile.path, 'rb') do |file|
-        while chunk = file.read(chunk_size)
-          sleep(chunk_size.to_f / (throttle_speed_kbps * 1024)) # Sleep to throttle speed
-        end
-      end
-      
       file_handler = FileHandler.new(file, env['cache'], ttl)
       hashed_link = file_handler.save
   
@@ -66,18 +53,15 @@ class Anonymoose < Sinatra::Base
       context.add_log_data(:file_extension, File.extname(file[:filename]))
   
       if hashed_link
-        erb :upload_success, locals: { link: hashed_link }
+        content_type :json  # Ensure the response is JSON because we are using FilePond
+        { link: "/uploads/#{hashed_link}" }.to_json  # Return JSON with the file link which FilePond will push to the client
       else
-        puts "File upload failed"
-        @error_message = "File upload failed. Please upload a valid file."
-        erb :upload
+        halt 500, 'File upload failed. Please try again.'
       end
-    else
-      puts "No file received"
-      @error_message = "No file received"
-      erb :upload
     end
   end
+  
+  
 
   get '/uploads/:hash' do
     hash = params[:hash]

--- a/app.rb
+++ b/app.rb
@@ -30,6 +30,8 @@ class Anonymoose < Sinatra::Base
   end
 
   post '/upload' do
+    puts "Received params: #{params.inspect}"
+
     ttl = params[:expiration].to_i
     file = params[:file]
     context = env['request_context']

--- a/app/middleware/headers_middleware.rb
+++ b/app/middleware/headers_middleware.rb
@@ -34,6 +34,6 @@ class HeadersMiddleware
   end
 
   def csp_header(nonce)
-    "default-src 'self'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com 'nonce-#{nonce}'; script-src 'self' https://cdn.jsdelivr.net; img-src 'self' data:; font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self';"
+    "default-src 'self'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com https://unpkg.com 'nonce-#{nonce}'; script-src 'self' https://cdn.jsdelivr.net https://unpkg.com; img-src 'self' data:; font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self';"
   end
 end

--- a/app/middleware/logging_middleware.rb
+++ b/app/middleware/logging_middleware.rb
@@ -14,6 +14,9 @@ class LoggingMiddleware
     status, headers, response = @app.call(env)
     duration = Time.now - start_time
 
+    context.status = status
+    context.duration = duration
+    context.headers = headers
     # Might be a temp log entry but currently it has a ton of useful data
     context.add_log_data(:env, env)
 

--- a/app/middleware/request_context.rb
+++ b/app/middleware/request_context.rb
@@ -6,6 +6,8 @@ class RequestContext
       timestamp: Time.now.iso8601,
       environment: ENVIRONMENT,
       method: nil,
+      headers: nil,
+      response: nil,
       path: nil,
       status: nil,
       duration: nil,
@@ -13,6 +15,17 @@ class RequestContext
       file_extension: nil,
       file_size: nil,
     }
+
+    # Dynamically define getter and setter methods for each log_data key
+    @log_data.each_key do |key|
+      define_singleton_method(key) do
+        @log_data[key]
+      end
+
+      define_singleton_method("#{key}=") do |value|
+        @log_data[key] = value
+      end
+    end
   end
 
   def add_log_data(key, value)

--- a/public/js/pond.js
+++ b/public/js/pond.js
@@ -1,0 +1,52 @@
+// public/js/pond3.js
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('file-upload-form');
+  
+  if (form) {
+    form.addEventListener('submit', (event) => {
+      event.preventDefault(); // Preventing traditional form submission (we also removed the upload button from upload.erb)
+    });
+  }
+
+  const inputElement = document.querySelector('input[type="file"]');
+  
+  if (inputElement) {
+    const pond = FilePond.create(inputElement, {
+      allowMultiple: false,
+      maxFiles: 1,
+      server: {
+        process: {
+          url: '/upload',
+          method: 'POST',
+          headers: {
+            // Add CSRF token???
+          },
+          ondata: (formData) => {
+            formData.append('expiration', document.querySelector('#expiration').value);
+            return formData;
+          },
+          onload: (response) => {
+            const jsonResponse = JSON.parse(response); // Parse the JSON response
+            const link = jsonResponse.link;
+
+            // Show success message with the link dynamically
+            const successMessage = `
+              <div class="alert alert-success">
+                File uploaded successfully! Your link: 
+                <a href="${link}" target="_blank">${link}</a>
+              </div>
+            `;
+
+            // Inject the message into the form or somewhere on the page
+            document.querySelector('article').insertAdjacentHTML('beforeend', successMessage);
+
+            console.log('File uploaded successfully:', link);
+          },
+          onerror: (response) => {
+            console.error('File upload error:', response);
+          }
+        }
+      }
+    });
+  }
+});

--- a/test/integration/anonoymoose_test.rb
+++ b/test/integration/anonoymoose_test.rb
@@ -46,7 +46,13 @@ class AnonymooseTest < Minitest::Test
     post '/upload', { file: file, expiration: 1 }
 
     assert last_response.ok?
-    assert_includes last_response.body, 'Upload Success'
+
+    # Parse the JSON response
+    json_response = JSON.parse(last_response.body)
+
+    # Assert that the response contains a link
+    assert_includes json_response, 'link'
+    assert_match %r{^/uploads/}, json_response['link'], "Expected a valid link in the response"
   end
 
   private

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -7,6 +7,12 @@
   <link href="https://cdn.jsdelivr.net/npm/beercss@3.6.5/dist/cdn/beer.min.css" rel="stylesheet" />
   <script type="module" src="https://cdn.jsdelivr.net/npm/beercss@3.6.5/dist/cdn/beer.min.js"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/material-dynamic-colors@1.1.2/dist/cdn/material-dynamic-colors.min.js"></script>
+
+  <!-- FilePond CSS -->
+  <link href="https://unpkg.com/filepond@^4/dist/filepond.css" rel="stylesheet" />
+  <!-- FilePond JS -->
+  <script src="https://unpkg.com/filepond@^4/dist/filepond.js"></script>
+
   <link rel="icon" href="/images/favicon.ico" />
 
   <% nonce = Thread.current[:style_nonce] %>

--- a/views/upload.erb
+++ b/views/upload.erb
@@ -6,12 +6,10 @@
   <% if @error_message %>
     <p class="error"><%= @error_message %></p>
   <% end %>
-  <form action="/upload" method="post" enctype="multipart/form-data">
+  <form id="file-upload-form" action="/upload" method="post" enctype="multipart/form-data">
     <div class="field">
-      <button class="circle">
-        <i>attach_file</i>
-        <input type="file" id="upload-file" name="file">
-      </button>
+      <label for="upload-file">Choose a file:</label>
+      <input type="file" id="upload-file" name="file">
     </div>
     <div class="field">
       <label for="expiration">Choose expiration:</label>
@@ -23,6 +21,8 @@
         <option value="5">1 Day</option>
       </select>
     </div>
-    <button type="submit" class="round">Upload</button>
   </form>
 </article>
+
+<!-- FilePond -->
+<script src="/js/pond.js"></script>


### PR DESCRIPTION
Initially, for uploading we had a simple form and when you clicked upload it would start the process. It probably isn't a big deal for small files but you don't know how long it will be until you get forwarded to the success page, and it's hard to tell if anything froze.

I moved to using FilePond which shows an upload status, once the upload is complete, a link is added via a div below the form, now we aren't routing to the success side either. 

If all goes well in production, I will remove the other routes and files that are no longer necessary.