### PR TITLE
moved max file size check to filepond

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -41,9 +41,6 @@ class Anonymoose < Sinatra::Base
     end
   
     file_size = file[:tempfile].size
-    if file_size > MAX_UPLOAD_SIZE
-      halt 413, 'File size exceeds the maximum limit'
-    end
   
     if file
       file_handler = FileHandler.new(file, env['cache'], ttl)

--- a/public/js/pond.js
+++ b/public/js/pond.js
@@ -1,4 +1,5 @@
-// public/js/pond3.js
+FilePond.registerPlugin(FilePondPluginFileValidateSize);
+
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('file-upload-form');
   
@@ -13,6 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
   if (inputElement) {
     const pond = FilePond.create(inputElement, {
       allowMultiple: false,
+      allowFileSizeValidation: true,
+      maxFileSize: '5MB',
       maxFiles: 1,
       server: {
         process: {
@@ -29,11 +32,12 @@ document.addEventListener('DOMContentLoaded', () => {
             const jsonResponse = JSON.parse(response); // Parse the JSON response
             const link = jsonResponse.link;
 
+            const fullLink = `${window.location.origin}${link}`;
             // Show success message with the link dynamically
             const successMessage = `
               <div class="alert alert-success">
                 File uploaded successfully! Your link: 
-                <a href="${link}" target="_blank">${link}</a>
+                <a href="${fullLink}" target="_blank">${fullLink}</a>
               </div>
             `;
 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -12,6 +12,8 @@
   <link href="https://unpkg.com/filepond@^4/dist/filepond.css" rel="stylesheet" />
   <!-- FilePond JS -->
   <script src="https://unpkg.com/filepond@^4/dist/filepond.js"></script>
+  <script src="https://unpkg.com/filepond-plugin-file-validate-size/dist/filepond-plugin-file-validate-size.js"></script>
+  <%# <script src="https://unpkg.com/filepond/dist/filepond.js"></script> %>
 
   <link rel="icon" href="/images/favicon.ico" />
 

--- a/views/upload.erb
+++ b/views/upload.erb
@@ -3,6 +3,7 @@
 <article class="border">
   <h5>Upload</h5>
   <p>Upload a file. Uploads will expire after a duration and be deleted from the servers.</p>
+  <p class="bold">Maximum Upload size is 5MB</p>
   <% if @error_message %>
     <p class="error"><%= @error_message %></p>
   <% end %>


### PR DESCRIPTION
filepond has it's own built in file size validation. Before the move, filepond would upload the full file and then just have a generic error when the back end did the file size check. now Filepond handles the check.