### PR TITLE
Switched to connection pool for S3

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -105,9 +105,7 @@ class Anonymoose < Sinatra::Base
     begin
       resp = s3_handler.download_file(unique_id)
       file_data = resp.body.read
-
-      # Debugging: Check the first few bytes of the file data
-      puts "File content preview: #{file_data[0, 100].inspect}"
+      puts "Downloaded file with size: #{file_data.size}"
 
       file_data
     rescue => e

--- a/app/handlers/s3_connection.rb
+++ b/app/handlers/s3_connection.rb
@@ -1,0 +1,40 @@
+require 'aws-sdk-s3'
+
+module S3Connection
+  @client = nil
+  @bucket_name = ENV['S3_BUCKET'] || 'development-bucket'
+
+  def self.client
+    Aws::S3::Client.new(
+      endpoint: ENV['S3_ENDPOINT'] || 'http://localhost:9000',
+      region: ENV['S3_REGION'] || 'us-east-1',
+      access_key_id: ENV['S3_ACCESS_KEY_ID'] || 'development',
+      secret_access_key: ENV['S3_SECRET_ACCESS_KEY'] || 'development',
+      force_path_style: true,
+    )
+  end
+
+  def self.bucket_name
+    @bucket_name
+  end
+
+  def self.reset_client
+    @client = nil
+  end
+
+  private
+
+  def self.create_bucket_unless_exists
+    unless bucket_exists?
+      client.create_bucket(bucket: @bucket_name)
+      puts "Bucket #{@bucket_name} created."
+    end
+  end
+
+  def self.bucket_exists?
+    client.head_bucket(bucket: @bucket_name)
+    true
+  rescue Aws::S3::Errors::NotFound
+    false
+  end
+end

--- a/app/handlers/s3_handler.rb
+++ b/app/handlers/s3_handler.rb
@@ -1,16 +1,9 @@
-require 'aws-sdk-s3'
+require_relative 's3_connection'
 
 class S3Handler
   def initialize
-    @client = Aws::S3::Client.new(
-      endpoint: ENV['S3_ENDPOINT'] || 'http://localhost:9000',
-      region: ENV['S3_REGION'] || 'us-east-1',
-      access_key_id: ENV['S3_ACCESS_KEY_ID'] || 'development',
-      secret_access_key: ENV['S3_SECRET_ACCESS_KEY'] || 'development',
-      force_path_style: true,
-    )
-    @bucket = ENV['S3_BUCKET'] || 'development-bucket'
-    create_bucket_unless_exists
+    @client = S3Connection.client
+    @bucket = S3Connection.bucket_name
   end
 
   def upload_file(tempfile, unique_id, ttl)
@@ -33,25 +26,5 @@ class S3Handler
   rescue => e
     puts "Error downloading file from S3: #{e.message}"
     raise
-  end
-
-  private
-
-  def create_bucket_unless_exists
-    unless bucket_exists?
-      @client.create_bucket(bucket: @bucket)
-      puts "Bucket #{@bucket} created."
-    else
-      puts "Bucket #{@bucket} already exists."
-    end
-  rescue Aws::S3::Errors::BucketAlreadyExists, Aws::S3::Errors::BucketAlreadyOwnedByYou
-    puts "Bucket #{@bucket} already exists."
-  end
-
-  def bucket_exists?
-    @client.head_bucket(bucket: @bucket)
-    true
-  rescue Aws::S3::Errors::NotFound
-    false
   end
 end


### PR DESCRIPTION
The `S3_Handler` class was creating a client connection and checking for a bucket every time an instance of the class was created. Client and Bucket creation checks were moved to a module that loads on boot and passes that info into the `S3_Handler` class. The `AWS::S3::Client` comes with a connection pool built in making the switch much easier.