### PR TITLE
moving to curl commands for buildkite to discord

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,15 @@ steps:
       - git clone https://github.com/EvilGenius13/Anonymoose.git
       - cd Anonymoose
       - scripts/deploy.sh
+      - |
+        if [ "$BUILDKITE_COMMAND_EXIT_STATUS" -eq 0 ]; then
+          curl -X POST "${DISCORD_WEBHOOK_URL}" \
+          -H "Content-Type: application/json" \
+          -d '{"content": "Deployment successful :rocket:"}'
+        else
+          curl -X POST "${DISCORD_WEBHOOK_URL}" \
+          -H "Content-Type: application/json" \
+          -d '{"content": "Deployment failed :x:"}'
+        fi
     env:
       KUBECONFIG: /home/ubuntu/.kube/config
-notify:
-  - webhook: "${DISCORD_WEBHOOK_URL}"


### PR DESCRIPTION
This change is necessary as buildkite doesn't support webhooks for discord